### PR TITLE
feat(sort-shuffle): accept Option<Partitioning>

### DIFF
--- a/ballista/core/src/execution_plans/sort_shuffle/writer.rs
+++ b/ballista/core/src/execution_plans/sort_shuffle/writer.rs
@@ -77,8 +77,9 @@ pub struct SortShuffleWriterExec {
     plan: Arc<dyn ExecutionPlan>,
     /// Path to write output streams to
     work_dir: String,
-    /// Shuffle output partitioning (must be Hash partitioning)
-    shuffle_output_partitioning: Partitioning,
+    /// Shuffle output partitioning. `None` means the input is passed through to
+    /// a single output partition without re-partitioning.
+    shuffle_output_partitioning: Option<Partitioning>,
     /// Sort shuffle configuration
     config: SortShuffleConfig,
     /// Execution metrics
@@ -127,22 +128,25 @@ impl SortShuffleWriterExec {
         stage_id: usize,
         plan: Arc<dyn ExecutionPlan>,
         work_dir: String,
-        shuffle_output_partitioning: Partitioning,
+        shuffle_output_partitioning: Option<Partitioning>,
         config: SortShuffleConfig,
     ) -> Result<Self> {
-        // Sort shuffle only supports hash partitioning
-        match &shuffle_output_partitioning {
-            Partitioning::Hash(_, _) => {}
-            other => {
+        if let Some(p) = &shuffle_output_partitioning {
+            if !matches!(p, Partitioning::Hash(_, _)) {
                 return Err(DataFusionError::Plan(format!(
-                    "SortShuffleWriterExec only supports Hash partitioning, got: {other:?}"
+                    "SortShuffleWriterExec only supports Hash or None partitioning, got: {p:?}"
                 )));
             }
         }
 
+        // When no shuffle partitioning is requested, mirror ShuffleWriterExec and
+        // pass the input plan's partitioning through unchanged.
+        let plan_partitioning = shuffle_output_partitioning
+            .clone()
+            .unwrap_or_else(|| plan.properties().output_partitioning().clone());
         let properties = Arc::new(PlanProperties::new(
             datafusion::physical_expr::EquivalenceProperties::new(plan.schema()),
-            shuffle_output_partitioning.clone(),
+            plan_partitioning,
             datafusion::physical_plan::execution_plan::EmissionType::Incremental,
             datafusion::physical_plan::execution_plan::Boundedness::Bounded,
         ));
@@ -169,9 +173,10 @@ impl SortShuffleWriterExec {
         self.stage_id
     }
 
-    /// Get the shuffle output partitioning
-    pub fn shuffle_output_partitioning(&self) -> &Partitioning {
-        &self.shuffle_output_partitioning
+    /// Get the shuffle output partitioning, or `None` if the writer passes
+    /// the input through to a single output partition.
+    pub fn shuffle_output_partitioning(&self) -> Option<&Partitioning> {
+        self.shuffle_output_partitioning.as_ref()
     }
 
     /// Get the sort shuffle configuration
@@ -206,10 +211,15 @@ impl SortShuffleWriterExec {
             let mut stream = plan.execute(input_partition, context)?;
             let schema = stream.schema();
 
-            let Partitioning::Hash(exprs, num_output_partitions) = partitioning else {
-                return Err(DataFusionError::Internal(
-                    "Expected hash partitioning".to_string(),
-                ));
+            // None => single output bucket (pass-through); Hash(_, n) => n buckets.
+            let num_output_partitions = match &partitioning {
+                Some(Partitioning::Hash(_, n)) => *n,
+                None => 1,
+                Some(other) => {
+                    return Err(DataFusionError::Internal(format!(
+                        "Unexpected partitioning in SortShuffleWriterExec: {other:?}"
+                    )));
+                }
             };
 
             // Create partition buffers
@@ -227,26 +237,32 @@ impl SortShuffleWriterExec {
             )
             .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?;
 
-            // Create batch partitioner
-            let mut partitioner = BatchPartitioner::new_hash_partitioner(
-                exprs,
-                num_output_partitions,
-                metrics.repart_time.clone(),
-            );
+            // Create batch partitioner only when actually re-partitioning by hash.
+            let mut partitioner = match &partitioning {
+                Some(Partitioning::Hash(exprs, n)) => Some(
+                    BatchPartitioner::new_hash_partitioner(
+                        exprs.clone(),
+                        *n,
+                        metrics.repart_time.clone(),
+                    ),
+                ),
+                _ => None,
+            };
 
             // Process input stream
             while let Some(result) = stream.next().await {
                 let input_batch = result?;
                 metrics.input_rows.add(input_batch.num_rows());
 
-                // Partition the batch
-                partitioner.partition(
-                    input_batch,
-                    |output_partition, output_batch| {
+                if let Some(p) = partitioner.as_mut() {
+                    p.partition(input_batch, |output_partition, output_batch| {
                         buffers[output_partition].append(output_batch);
                         Ok(())
-                    },
-                )?;
+                    })?;
+                } else {
+                    // No partitioning: route everything to bucket 0.
+                    buffers[0].append(input_batch);
+                }
 
                 // Check if we need to spill
                 let total_memory: usize = buffers.iter().map(|b| b.memory_used()).sum();
@@ -468,16 +484,17 @@ impl DisplayAs for SortShuffleWriterExec {
         t: DisplayFormatType,
         f: &mut std::fmt::Formatter,
     ) -> std::fmt::Result {
+        let partitioning = self
+            .shuffle_output_partitioning
+            .as_ref()
+            .map(|p| p.to_string())
+            .unwrap_or_else(|| "None".to_string());
         match t {
             DisplayFormatType::Default | DisplayFormatType::Verbose => {
-                write!(
-                    f,
-                    "SortShuffleWriterExec: partitioning={}",
-                    self.shuffle_output_partitioning
-                )
+                write!(f, "SortShuffleWriterExec: partitioning={partitioning}")
             }
             DisplayFormatType::TreeRender => {
-                write!(f, "partitioning={}", self.shuffle_output_partitioning)
+                write!(f, "partitioning={partitioning}")
             }
         }
     }
@@ -627,7 +644,7 @@ impl ShuffleWriter for SortShuffleWriterExec {
     }
 
     fn shuffle_output_partitioning(&self) -> Option<&Partitioning> {
-        Some(&self.shuffle_output_partitioning)
+        self.shuffle_output_partitioning.as_ref()
     }
 
     fn input_partition_count(&self) -> usize {
@@ -716,7 +733,7 @@ mod tests {
             1,
             input_plan,
             work_dir.path().to_str().unwrap().to_string(),
-            Partitioning::Hash(vec![Arc::new(Column::new("a", 0))], 2),
+            Some(Partitioning::Hash(vec![Arc::new(Column::new("a", 0))], 2)),
             config,
         )?;
 
@@ -736,6 +753,63 @@ mod tests {
         assert!(output_dir.join("data.arrow").exists());
         assert!(output_dir.join("data.arrow.index").exists());
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_sort_shuffle_with_no_partitioning() -> Result<()> {
+        use crate::execution_plans::sort_shuffle::reader::read_sort_shuffle_partition;
+
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
+
+        let work_dir = TempDir::new()?;
+        let work_dir_str = work_dir.path().to_str().unwrap().to_string();
+
+        let input = create_test_input()?;
+        // create_test_input(): 2 input partitions × 2 batches × 2 rows = 8 rows total
+        let num_input_partitions =
+            input.properties().output_partitioning().partition_count();
+
+        let writer = SortShuffleWriterExec::try_new(
+            "job-none".to_string(),
+            1,
+            input,
+            work_dir_str.clone(),
+            None,
+            SortShuffleConfig::default(),
+        )?;
+
+        let mut total_rows = 0u64;
+        for input_partition in 0..num_input_partitions {
+            let results = writer
+                .clone()
+                .execute_shuffle_write(input_partition, task_ctx.clone())
+                .await?;
+
+            // Exactly one output partition (partition 0) per input partition
+            assert_eq!(results.len(), 1, "expected 1 output partition");
+            assert_eq!(results[0].partition_id, 0);
+            assert!(results[0].is_sort_shuffle);
+            total_rows += results[0].num_rows;
+
+            // Verify the data file is readable via the sort-shuffle reader
+            let data_path = work_dir
+                .path()
+                .join("job-none")
+                .join("1")
+                .join(format!("{input_partition}"))
+                .join("data.arrow");
+            let index_path = data_path.with_extension("arrow.index");
+            assert!(data_path.exists(), "data file missing");
+            assert!(index_path.exists(), "index file missing");
+
+            let batches = read_sort_shuffle_partition(&data_path, &index_path, 0)
+                .map_err(|e| DataFusionError::Execution(format!("{e:?}")))?;
+            let read_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+            assert_eq!(read_rows as u64, results[0].num_rows);
+        }
+        assert_eq!(total_rows, 8); // 2 partitions × 2 batches × 2 rows
         Ok(())
     }
 }

--- a/ballista/core/src/execution_plans/sort_shuffle/writer.rs
+++ b/ballista/core/src/execution_plans/sort_shuffle/writer.rs
@@ -131,12 +131,12 @@ impl SortShuffleWriterExec {
         shuffle_output_partitioning: Option<Partitioning>,
         config: SortShuffleConfig,
     ) -> Result<Self> {
-        if let Some(p) = &shuffle_output_partitioning {
-            if !matches!(p, Partitioning::Hash(_, _)) {
-                return Err(DataFusionError::Plan(format!(
-                    "SortShuffleWriterExec only supports Hash or None partitioning, got: {p:?}"
-                )));
-            }
+        if let Some(p) = &shuffle_output_partitioning
+            && !matches!(p, Partitioning::Hash(_, _))
+        {
+            return Err(DataFusionError::Plan(format!(
+                "SortShuffleWriterExec only supports Hash or None partitioning, got: {p:?}"
+            )));
         }
 
         // When no shuffle partitioning is requested, mirror ShuffleWriterExec and
@@ -239,13 +239,13 @@ impl SortShuffleWriterExec {
 
             // Create batch partitioner only when actually re-partitioning by hash.
             let mut partitioner = match &partitioning {
-                Some(Partitioning::Hash(exprs, n)) => Some(
-                    BatchPartitioner::new_hash_partitioner(
+                Some(Partitioning::Hash(exprs, n)) => {
+                    Some(BatchPartitioner::new_hash_partitioner(
                         exprs.clone(),
                         *n,
                         metrics.repart_time.clone(),
-                    ),
-                ),
+                    ))
+                }
                 _ => None,
             };
 

--- a/ballista/core/src/serde/mod.rs
+++ b/ballista/core/src/serde/mod.rs
@@ -370,12 +370,6 @@ impl PhysicalExtensionCodec for BallistaPhysicalExtensionCodec {
                     &converter,
                 )?;
 
-                let partitioning = shuffle_output_partitioning.ok_or_else(|| {
-                    DataFusionError::Internal(
-                        "SortShuffleWriterExec requires hash partitioning".to_string(),
-                    )
-                })?;
-
                 let batch_size = if sort_shuffle_writer.batch_size > 0 {
                     sort_shuffle_writer.batch_size as usize
                 } else {
@@ -395,7 +389,7 @@ impl PhysicalExtensionCodec for BallistaPhysicalExtensionCodec {
                     sort_shuffle_writer.stage_id as usize,
                     input,
                     "".to_string(), // executor will fill this in
-                    partitioning,
+                    shuffle_output_partitioning,
                     config,
                 )?))
             }
@@ -503,7 +497,7 @@ impl PhysicalExtensionCodec for BallistaPhysicalExtensionCodec {
             Ok(())
         } else if let Some(exec) = node.as_any().downcast_ref::<SortShuffleWriterExec>() {
             let output_partitioning = match exec.shuffle_output_partitioning() {
-                Partitioning::Hash(exprs, partition_count) => {
+                Some(Partitioning::Hash(exprs, partition_count)) => {
                     Some(datafusion_proto::protobuf::PhysicalHashRepartition {
                         hash_expr: exprs
                             .iter()
@@ -517,9 +511,10 @@ impl PhysicalExtensionCodec for BallistaPhysicalExtensionCodec {
                         partition_count: *partition_count as u64,
                     })
                 }
-                other => {
+                None => None,
+                Some(other) => {
                     return Err(DataFusionError::Internal(format!(
-                        "SortShuffleWriterExec requires Hash partitioning, got: {other:?}"
+                        "SortShuffleWriterExec requires Hash or None partitioning, got: {other:?}"
                     )));
                 }
             };

--- a/ballista/executor/src/execution_engine.rs
+++ b/ballista/executor/src/execution_engine.rs
@@ -129,7 +129,7 @@ impl ExecutionEngine for DefaultExecutionEngine {
                 stage_id,
                 plan.children()[0].clone(),
                 work_dir.to_string(),
-                sort_shuffle_writer.shuffle_output_partitioning().clone(),
+                sort_shuffle_writer.shuffle_output_partitioning().cloned(),
                 sort_shuffle_writer.config().clone(),
             )?;
             Ok(Arc::new(DefaultQueryStageExec::new(

--- a/ballista/scheduler/src/planner.rs
+++ b/ballista/scheduler/src/planner.rs
@@ -355,7 +355,7 @@ fn create_shuffle_writer_with_config(
                 stage_id,
                 plan,
                 "".to_owned(),
-                Partitioning::Hash(exprs, partition_count),
+                Some(Partitioning::Hash(exprs, partition_count)),
                 sort_config,
             )?));
         }

--- a/ballista/scheduler/src/planner.rs
+++ b/ballista/scheduler/src/planner.rs
@@ -338,27 +338,26 @@ fn create_shuffle_writer_with_config(
         .cloned()
         .unwrap_or_default();
 
-    if ballista_config.shuffle_sort_based_enabled() {
-        // Sort shuffle requires hash partitioning
-        if let Some(Partitioning::Hash(exprs, partition_count)) = partitioning {
-            let sort_config = SortShuffleConfig::new(
-                true,
-                ballista_config.shuffle_sort_based_buffer_size(),
-                ballista_config.shuffle_sort_based_memory_limit(),
-                ballista_config.shuffle_sort_based_spill_threshold(),
-                datafusion::arrow::ipc::CompressionType::LZ4_FRAME,
-                ballista_config.shuffle_sort_based_batch_size(),
-            );
+    if ballista_config.shuffle_sort_based_enabled()
+        && matches!(partitioning, None | Some(Partitioning::Hash(_, _)))
+    {
+        let sort_config = SortShuffleConfig::new(
+            true,
+            ballista_config.shuffle_sort_based_buffer_size(),
+            ballista_config.shuffle_sort_based_memory_limit(),
+            ballista_config.shuffle_sort_based_spill_threshold(),
+            datafusion::arrow::ipc::CompressionType::LZ4_FRAME,
+            ballista_config.shuffle_sort_based_batch_size(),
+        );
 
-            return Ok(Arc::new(SortShuffleWriterExec::try_new(
-                job_id.to_owned(),
-                stage_id,
-                plan,
-                "".to_owned(),
-                Some(Partitioning::Hash(exprs, partition_count)),
-                sort_config,
-            )?));
-        }
+        return Ok(Arc::new(SortShuffleWriterExec::try_new(
+            job_id.to_owned(),
+            stage_id,
+            plan,
+            "".to_owned(),
+            partitioning,
+            sort_config,
+        )?));
     }
 
     // Fall back to standard shuffle writer
@@ -376,7 +375,9 @@ mod test {
     use crate::planner::{DefaultDistributedPlanner, DistributedPlanner};
     use crate::test_utils::datafusion_test_context;
     use ballista_core::error::BallistaError;
-    use ballista_core::execution_plans::{ShuffleWriterExec, UnresolvedShuffleExec};
+    use ballista_core::execution_plans::{
+        ShuffleWriterExec, SortShuffleWriterExec, UnresolvedShuffleExec,
+    };
     use ballista_core::serde::BallistaCodec;
     use datafusion::arrow::compute::SortOptions;
     use datafusion::execution::TaskContext;
@@ -830,6 +831,53 @@ order by
             format!("{partial_hash_serde:?}")
         );
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn sort_shuffle_used_for_none_partitioning() -> Result<(), BallistaError> {
+        use ballista_core::config::BallistaConfig;
+        use datafusion::config::{ConfigOptions, ExtensionOptions};
+
+        // With sort-based shuffle enabled, every stage in the distributed plan
+        // should use SortShuffleWriterExec - including the final stage(s)
+        // whose shuffle partitioning is None.
+        let ctx = datafusion_test_context("testdata").await?;
+        let session_state = ctx.state();
+
+        let df = ctx
+            .sql(
+                "select l_returnflag, sum(l_extendedprice) as total
+            from lineitem
+            group by l_returnflag
+            order by l_returnflag",
+            )
+            .await?;
+        let plan = df.into_optimized_plan()?;
+        let plan = session_state.optimize(&plan)?;
+        let plan = session_state.create_physical_plan(&plan).await?;
+
+        let mut ballista_config = BallistaConfig::default();
+        ballista_config
+            .set("shuffle.sort_based.enabled", "true")
+            .expect("set sort-based-enabled");
+        let mut config_options = ConfigOptions::new();
+        config_options.extensions.insert(ballista_config);
+
+        let mut planner = DefaultDistributedPlanner::new();
+        let stages = planner.plan_query_stages("job-none", plan, &config_options)?;
+
+        // The query produces multiple stages: a Hash-partitioned partial
+        // aggregate, a None-partitioned final-aggregate, and a None-partitioned
+        // sort-preserving merge. All should be SortShuffleWriterExec.
+        assert!(stages.len() >= 2, "expected at least 2 stages");
+        for (i, stage) in stages.iter().enumerate() {
+            assert!(
+                stage.as_any().downcast_ref::<SortShuffleWriterExec>().is_some(),
+                "stage {i} expected SortShuffleWriterExec, got {}",
+                stage.name()
+            );
+        }
         Ok(())
     }
 

--- a/ballista/scheduler/src/planner.rs
+++ b/ballista/scheduler/src/planner.rs
@@ -873,7 +873,10 @@ order by
         assert!(stages.len() >= 2, "expected at least 2 stages");
         for (i, stage) in stages.iter().enumerate() {
             assert!(
-                stage.as_any().downcast_ref::<SortShuffleWriterExec>().is_some(),
+                stage
+                    .as_any()
+                    .downcast_ref::<SortShuffleWriterExec>()
+                    .is_some(),
                 "stage {i} expected SortShuffleWriterExec, got {}",
                 stage.name()
             );

--- a/ballista/scheduler/src/state/execution_graph.rs
+++ b/ballista/scheduler/src/state/execution_graph.rs
@@ -1719,7 +1719,8 @@ impl TaskDescription {
         {
             return shuffle_writer
                 .shuffle_output_partitioning()
-                .partition_count();
+                .map(|partitioning| partitioning.partition_count())
+                .unwrap_or(1);
         }
         // Default fallback
         1

--- a/benchmarks/benches/sort_shuffle.rs
+++ b/benchmarks/benches/sort_shuffle.rs
@@ -234,7 +234,10 @@ fn run_sort_shuffle(
         1,
         input,
         work_dir.to_string(),
-        Partitioning::Hash(vec![Arc::new(Column::new("c0", 0))], NUM_OUTPUT_PARTITIONS),
+        Some(Partitioning::Hash(
+            vec![Arc::new(Column::new("c0", 0))],
+            NUM_OUTPUT_PARTITIONS,
+        )),
         config,
     )
     .unwrap();

--- a/benchmarks/src/bin/shuffle_bench.rs
+++ b/benchmarks/src/bin/shuffle_bench.rs
@@ -235,10 +235,10 @@ async fn benchmark_sort_shuffle(
         1,
         input,
         work_dir.to_owned(),
-        Partitioning::Hash(
+        Some(Partitioning::Hash(
             vec![Arc::new(Column::new("partition_key", 1))],
             output_partitions,
-        ),
+        )),
         config,
     )?;
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change

`SortShuffleWriterExec` previously only supported `Partitioning::Hash`. Stages with `partitioning=None` (final output, `CoalescePartitionsExec`, `SortPreservingMergeExec`) had to fall back to `ShuffleWriterExec`, leaving two writer code paths and two on-disk shuffle formats coexisting in executor work directories. Extending sort-shuffle to handle `None` lets every stage use one writer when sort-based shuffle is enabled and is a prerequisite for removing the legacy hash-based writer entirely.

# What changes are included in this PR?

- `SortShuffleWriterExec::try_new` now takes `Option<Partitioning>` (mirroring `ShuffleWriterExec`). When `None`, the writer skips hashing and writes a single-partition data+index file with every input row in bucket 0.
- `shuffle_output_partitioning()` returns `Option<&Partitioning>`.
- Encoder/decoder in `ballista_core::serde` accept the absent `output_partitioning` field on `SortShuffleWriterExecNode` (the proto field is implicitly optional, so no proto change).
- `DefaultDistributedPlanner::create_shuffle_writer_with_config` selects sort-shuffle for any supported partitioning (`Hash` or `None`) when `BALLISTA_SHUFFLE_SORT_BASED_ENABLED` is on, instead of falling back to `ShuffleWriterExec`.
- New unit tests exercise the writer with `None` and the planner routing decision.

# Are there any user-facing changes?

The signature of `SortShuffleWriterExec::try_new` and `shuffle_output_partitioning()` change shape (`Partitioning` -> `Option<Partitioning>`). The `BALLISTA_SHUFFLE_SORT_BASED_ENABLED` config still controls the choice of writer; the difference is that when enabled, all stages use sort-shuffle, not just the hash-partitioned ones.