### PR TITLE
test: cover DF-promoted CollectLeft broadcast safety gap

### DIFF
--- a/ballista/scheduler/src/planner.rs
+++ b/ballista/scheduler/src/planner.rs
@@ -1048,6 +1048,99 @@ order by
         Ok(())
     }
 
+    // Under the production session config the DF threshold is also 10 MB (set
+    // in `extension.rs` by this PR), so DF's own `JoinSelection` runs first
+    // and can produce `HashJoinExec(LEFT, CollectLeft)` for
+    // `small LEFT JOIN big` — no swap, because the small side is already on
+    // the left. `maybe_promote_to_broadcast` only guards
+    // `Partitioned → CollectLeft`, so a pre-promoted plan reaches the
+    // broadcast-lowering branch in `plan_query_stages_internal` (above) and
+    // gets broadcast without the new `collect_left_broadcast_safe` check.
+    #[tokio::test]
+    async fn df_promoted_left_join_must_not_broadcast() -> Result<(), BallistaError> {
+        use ballista_core::extension::SessionConfigExt;
+        use datafusion::arrow::array::Int32Array;
+        use datafusion::arrow::datatypes::{DataType, Field, Schema};
+        use datafusion::arrow::record_batch::RecordBatch;
+        use datafusion::common::JoinType;
+        use datafusion::physical_plan::joins::PartitionMode;
+        use datafusion::prelude::SessionConfig;
+
+        let big_schema = Arc::new(Schema::new(vec![
+            Field::new("k", DataType::Int32, false),
+            Field::new("v", DataType::Int32, false),
+        ]));
+        let small_schema = Arc::new(Schema::new(vec![
+            Field::new("k", DataType::Int32, false),
+            Field::new("w", DataType::Int32, false),
+        ]));
+        let big_batch = RecordBatch::try_new(
+            big_schema,
+            vec![
+                Arc::new(Int32Array::from((0..10_000).collect::<Vec<_>>())),
+                Arc::new(Int32Array::from((0..10_000).collect::<Vec<_>>())),
+            ],
+        )
+        .map_err(|e| BallistaError::General(e.to_string()))?;
+        let small_batch = RecordBatch::try_new(
+            small_schema,
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2])),
+                Arc::new(Int32Array::from(vec![10, 20])),
+            ],
+        )
+        .map_err(|e| BallistaError::General(e.to_string()))?;
+
+        // Match the PR's production session config: DF and Ballista thresholds
+        // both at 10 MB so DF's `JoinSelection` can promote on its own.
+        let session_config = SessionConfig::new()
+            .with_target_partitions(2)
+            .set_bool("datafusion.optimizer.prefer_hash_join", true)
+            .set_usize(
+                "datafusion.optimizer.hash_join_single_partition_threshold",
+                10 * 1024 * 1024,
+            )
+            .with_ballista_broadcast_join_threshold_bytes(10 * 1024 * 1024);
+        let ctx = datafusion::prelude::SessionContext::new_with_config(session_config);
+        ctx.register_batch("big", big_batch)?;
+        ctx.register_batch("small", small_batch)?;
+        let options = ctx.state().config().options().clone();
+
+        let plan = ctx
+            .sql("select * from small left join big on small.k = big.k")
+            .await?
+            .into_optimized_plan()?;
+        let plan = ctx.state().create_physical_plan(&plan).await?;
+
+        let mut planner = DefaultDistributedPlanner::new();
+        let job_uuid = Uuid::new_v4();
+        let stages =
+            planner.plan_query_stages(&job_uuid.to_string().into(), plan, &options)?;
+
+        for stage in &stages {
+            let mut walker: Vec<Arc<dyn ExecutionPlan>> =
+                vec![stage.clone() as Arc<dyn ExecutionPlan>];
+            while let Some(node) = walker.pop() {
+                if let Some(hj) = node.downcast_ref::<HashJoinExec>() {
+                    assert!(
+                        !(matches!(hj.join_type(), JoinType::Left)
+                            && *hj.partition_mode() == PartitionMode::CollectLeft),
+                        "LEFT join must not be CollectLeft (would broadcast the \
+                         outer side across probe tasks)"
+                    );
+                }
+                if let Some(unresolved) = node.downcast_ref::<UnresolvedShuffleExec>() {
+                    assert!(
+                        !unresolved.broadcast,
+                        "no broadcast reader expected for an unsafe LEFT join"
+                    );
+                }
+                walker.extend(node.children().iter().map(|c| (*c).clone()));
+            }
+        }
+        Ok(())
+    }
+
     // A LEFT join with the small side on the left builds (broadcasts) the left
     // side and emits a null-padded row for every unmatched left row; each probe
     // task would emit those independently. The guard must keep it repartitioned


### PR DESCRIPTION
Stacked on apache/datafusion-ballista#1900 — adds a single failing test that exposes a gap in the safety guard.

## What the test shows

With the new session defaults from #1900 (`hash_join_single_partition_threshold = 10 MB`), DataFusion's own `JoinSelection` runs during `create_physical_plan` and can produce `HashJoinExec(LEFT, CollectLeft)` for `small LEFT JOIN big` — no swap, because the small side is already on the left. `try_collect_left` in DF doesn't restrict by join type (it doesn't need to in standalone DF, where there's only one probe task).

Ballista's `maybe_promote_to_broadcast` short-circuits on `partition_mode != Partitioned` (`planner.rs:294`), so the new `collect_left_broadcast_safe` guard never sees the join. `plan_query_stages_internal` then lowers it via `UnresolvedShuffleExec::new_broadcast` at `planner.rs:145-184` — re-opening the #1055 unsafety that pinning the thresholds to zero used to prevent.

Reproducer output on this branch:

```
HashJoinExec: mode=CollectLeft, join_type=Left, on=[(k@0, k@0)]
  UnresolvedShuffleExec: broadcast=true, upstream_partitions: 1
  DataSourceExec: partitions=1, partition_sizes=[1]
```

## Why existing tests don't catch it

`make_broadcast_test_ctx` pins `datafusion.optimizer.hash_join_single_partition_threshold = 0` (`planner.rs:1494-1497`), so DF can never promote on its own in test sessions — only the Ballista promotion path is exercised, which is correctly guarded. The new test mirrors the production session (DF and Ballista thresholds both at 10 MB) so DF's `JoinSelection` is what does the promotion.

## Why AQE is unaffected

`DelayJoinSelectionRule` runs in `plan_preparation_optimizers` before DF's `JoinSelection` and wraps every `HashJoinExec` in a `DynamicJoinSelectionExec`, so DF's rule finds nothing to promote. The static path has no equivalent wrapper.

## Suggested fix shape (for #1900)

In `maybe_promote_to_broadcast`, when `partition_mode == CollectLeft` and `!collect_left_broadcast_safe(*hash_join.join_type())`, demote to `Partitioned` instead of returning early. Same predicate, same module.

This PR intentionally contains only the test — happy to land the fix here or in #1900, whichever you prefer.

## Checklist

- [ ] Documentation improved