### PR TITLE
test: cover empty GROUPING SETS subset in PropagateEmptyExecRule

### DIFF
--- a/ballista/scheduler/src/state/aqe/optimizer_rule/propagate_empty.rs
+++ b/ballista/scheduler/src/state/aqe/optimizer_rule/propagate_empty.rs
@@ -330,11 +330,11 @@ mod tests {
 
     use datafusion::{
         arrow::datatypes::{DataType, Field, Schema},
-        common::{ColumnStatistics, JoinType, NullEquality, Statistics},
+        common::{ColumnStatistics, JoinType, NullEquality, ScalarValue, Statistics},
         physical_expr::aggregate::AggregateExprBuilder,
         physical_plan::{
             aggregates::{AggregateMode, PhysicalGroupBy},
-            expressions::Column,
+            expressions::{Column, Literal},
             joins::PartitionMode,
             test::exec::StatisticsExec,
         },
@@ -943,6 +943,26 @@ mod tests {
             Arc::new(EmptyExec::new(schema())),
             PhysicalGroupBy::default(),
             AggregateMode::Partial,
+        );
+        assert_untouched(&transform(plan));
+    }
+
+    #[test]
+    fn aggregate_grouping_sets_with_empty_subset_over_empty_is_preserved() {
+        // `ROLLUP(a)` / `GROUPING SETS ((a), ())` lowers to a non-empty `expr`
+        // list plus a `groups` mask containing the all-null (empty) subset.
+        // Over zero input rows, that empty subset still emits one all-NULL row
+        // — matches DataFusion's logical `has_empty_grouping_set` guard.
+        let group_by = PhysicalGroupBy::new(
+            vec![(Arc::new(Column::new("a", 0)), "a".into())],
+            vec![(Arc::new(Literal::new(ScalarValue::Int32(None))), "a".into())],
+            vec![vec![false], vec![true]],
+            true,
+        );
+        let plan = aggregate(
+            Arc::new(EmptyExec::new(schema())),
+            group_by,
+            AggregateMode::Single,
         );
         assert_untouched(&transform(plan));
     }


### PR DESCRIPTION
Follow-up to your PR into apache/datafusion-ballista#2194.

DataFusion's logical `PropagateEmptyRelation` guards the aggregate arm on **two** conditions ([`datafusion-optimizer/src/propagate_empty_relation.rs`](https://github.com/apache/datafusion/blob/branch-54/datafusion/optimizer/src/propagate_empty_relation.rs#L182-L183)):

```rust
if !agg.group_expr.is_empty()
    && !has_empty_grouping_set(&agg.group_expr)
```

The physical port on your branch carries the first but not the second. A query with `GROUPING SETS ((a), ())` / `ROLLUP(a)` / `CUBE(a)` over an input that turns out empty still gets collapsed to `EmptyExec`, dropping the all-NULL row that the empty subset `()` should emit.

Attached test constructs that shape directly against `PhysicalGroupBy` (non-empty `expr`, `groups = [[false], [true]]`, `has_grouping_set = true`) and asserts the aggregate is preserved. It fails on your current branch:

```
thread '...aggregate_grouping_sets_with_empty_subset_over_empty_is_preserved'
  panicked at ...propagate_empty.rs:450:
  expected join to be untouched, got "EmptyExec"
```

No fix included — leaving that call to you. The physical equivalent of `has_empty_grouping_set` is "any element of `group_expr().groups()` is all-`true`" (all columns null-masked = the empty subset). Same shape catches `ROLLUP` and `CUBE` since both always expand to include `()`.